### PR TITLE
Added torch.squeeze to DSC and IoU

### DIFF
--- a/utils/running_loop.py
+++ b/utils/running_loop.py
@@ -77,6 +77,9 @@ def accuracy(pred, real):
     return acc/len(real)
 
 def IoU(pred, real):
+    pred = torch.squeeze(pred)
+    real = torch.squeeze(real)
+    
     pred = pred.view(-1)
     real = real.view(-1)
     intersection = (pred * real).sum()
@@ -87,6 +90,9 @@ def IoU(pred, real):
     return intersection/union
 
 def DSC(pred, real):
+    pred = torch.squeeze(pred) 
+    real = torch.squeeze(real)
+    
     pred = pred.view(-1)
     real = real.view(-1)
     intersection = (pred * real).sum()


### PR DESCRIPTION
I think there may be a mismatch between the shapes of the output of the model and the shape of the mask. I added a squeeze call to both the inputs of both functions to try to fix this. It is working for my limited implementation